### PR TITLE
Mapper agent sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,6 +647,7 @@ dependencies = [
  "async-trait",
  "c8y_api",
  "download",
+ "http",
  "log",
  "mqtt_channel",
  "tedge_actors",

--- a/crates/core/c8y_api/src/http_proxy.rs
+++ b/crates/core/c8y_api/src/http_proxy.rs
@@ -133,7 +133,6 @@ impl C8yMqttJwtTokenRetriever {
 
         // Wait till the bridge comes up
         while let Some(msg) = mqtt_con.received.next().await {
-            dbg!(&msg.topic.name);
             if is_c8y_bridge_up(&msg) {
                 break;
             }

--- a/crates/core/c8y_api/src/utils.rs
+++ b/crates/core/c8y_api/src/utils.rs
@@ -4,11 +4,22 @@ pub mod bridge {
 
     pub const C8Y_BRIDGE_HEALTH_TOPIC: &str = "tedge/health/mosquitto-c8y-bridge";
     const C8Y_BRIDGE_UP_PAYLOAD: &str = "1";
+    const C8Y_BRIDGE_DOWN_PAYLOAD: &str = "0";
 
     pub fn is_c8y_bridge_up(message: &Message) -> bool {
         match message.payload_str() {
             Ok(payload) => {
                 message.topic.name == C8Y_BRIDGE_HEALTH_TOPIC && payload == C8Y_BRIDGE_UP_PAYLOAD
+            }
+            Err(_err) => false,
+        }
+    }
+
+    pub fn is_c8y_bridge_established(message: &Message) -> bool {
+        match message.payload_str() {
+            Ok(payload) => {
+                message.topic.name == C8Y_BRIDGE_HEALTH_TOPIC
+                    && (payload == C8Y_BRIDGE_UP_PAYLOAD || payload == C8Y_BRIDGE_DOWN_PAYLOAD)
             }
             Err(_err) => false,
         }
@@ -26,11 +37,8 @@ pub mod tedge_agent {
         if message.topic.name.eq(TEDGE_AGENT_HEALTH_TOPIC) {
             match message.payload_str() {
                 Ok(payload) => {
-                    dbg!(&message.topic.name);
-                    let res = payload.contains(TEDGE_HEALTH_UP_PAYLOAD)
-                        || payload.contains(TEDGE_HEALTH_DOWN_PAYLOAD);
-                    dbg!(&res);
-                    res
+                    payload.contains(TEDGE_HEALTH_UP_PAYLOAD)
+                        || payload.contains(TEDGE_HEALTH_DOWN_PAYLOAD)
                 }
                 Err(_err) => false,
             }

--- a/crates/core/c8y_api/src/utils.rs
+++ b/crates/core/c8y_api/src/utils.rs
@@ -33,7 +33,7 @@ pub mod tedge_agent {
     const TEDGE_HEALTH_UP_PAYLOAD: &str = r#""status":"up""#;
     const TEDGE_HEALTH_DOWN_PAYLOAD: &str = r#""status":"down""#;
 
-    pub fn tedge_agent_status(message: &Message) -> bool {
+    pub fn check_tedge_agent_status(message: &Message) -> bool {
         if message.topic.name.eq(TEDGE_AGENT_HEALTH_TOPIC) {
             match message.payload_str() {
                 Ok(payload) => {

--- a/crates/core/c8y_api/src/utils.rs
+++ b/crates/core/c8y_api/src/utils.rs
@@ -15,6 +15,31 @@ pub mod bridge {
     }
 }
 
+pub mod tedge_agent {
+    use mqtt_channel::Message;
+
+    pub const TEDGE_AGENT_HEALTH_TOPIC: &str = "tedge/health/tedge-agent";
+    const TEDGE_HEALTH_UP_PAYLOAD: &str = r#""status":"up""#;
+    const TEDGE_HEALTH_DOWN_PAYLOAD: &str = r#""status":"down""#;
+
+    pub fn tedge_agent_status(message: &Message) -> bool {
+        if message.topic.name.eq(TEDGE_AGENT_HEALTH_TOPIC) {
+            match message.payload_str() {
+                Ok(payload) => {
+                    dbg!(&message.topic.name);
+                    let res = payload.contains(TEDGE_HEALTH_UP_PAYLOAD)
+                        || payload.contains(TEDGE_HEALTH_DOWN_PAYLOAD);
+                    dbg!(&res);
+                    res
+                }
+                Err(_err) => false,
+            }
+        } else {
+            false
+        }
+    }
+}
+
 pub mod child_device {
     use crate::smartrest::topic::SMARTREST_PUBLISH_TOPIC;
     use mqtt_channel::Message;

--- a/crates/extensions/c8y_http_proxy/Cargo.toml
+++ b/crates/extensions/c8y_http_proxy/Cargo.toml
@@ -13,6 +13,7 @@ repository = { workspace = true }
 async-trait = "0.1"
 c8y_api = { path = "../../core/c8y_api" }
 download = { path = "../../common/download" }
+http = "0.2"
 log = "0.4"
 mqtt_channel = { path = "../../common/mqtt_channel" }
 tedge_actors = { path = "../../core/tedge_actors" }

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -202,6 +202,7 @@ impl C8YHttpProxyActor {
         &mut self,
         device_id: Option<&str>,
     ) -> Result<HttpResult, C8YRestError> {
+        let mut sleep = 1;
         loop {
             let url_get_id = self.end_point.get_url_for_get_id(device_id);
             // Get a JWT token to authenticate the device
@@ -212,7 +213,7 @@ impl C8YHttpProxyActor {
             // TODO Add timeout
             let request = request_internal_id_req.build()?;
             let resp = self.peers.http.await_response(request).await?;
-            // Ok(self.peers.http.await_response(request).await?)
+
             match resp {
                 Ok(response) => return Ok(Ok(response)),
                 Err(e) => match e {
@@ -222,6 +223,9 @@ impl C8YHttpProxyActor {
                     | tedge_http_ext::HttpError::HttpStatusError(StatusCode::REQUEST_TIMEOUT) => {
                         // reset jwt token, so that we can get a fresh one on next iteration.
                         self.token = "".to_string();
+                        tokio::time::sleep(tokio::time::Duration::from_secs(sleep)).await;
+                        // Increase the sleep in exponential
+                        sleep *= 2;
                         continue;
                     }
                     e => return Err(C8YRestError::FromHttpError(e)),
@@ -246,6 +250,7 @@ impl C8YHttpProxyActor {
         &mut self,
         software_list: C8yUpdateSoftwareListResponse,
     ) -> Result<Unit, C8YRestError> {
+        let mut sleep = 1;
         loop {
             if self.end_point.c8y_internal_id.is_empty() {
                 self.try_get_and_set_internal_id().await?;
@@ -274,6 +279,9 @@ impl C8YHttpProxyActor {
                     | tedge_http_ext::HttpError::HttpStatusError(StatusCode::REQUEST_TIMEOUT) => {
                         self.token = "".to_string();
                         self.end_point.c8y_internal_id = "".to_string();
+                        tokio::time::sleep(tokio::time::Duration::from_secs(sleep)).await;
+                        // Increase the sleep in exponential
+                        sleep *= 2;
                         continue;
                     }
                     e => return Err(C8YRestError::FromHttpError(e)),
@@ -286,6 +294,7 @@ impl C8YHttpProxyActor {
         &mut self,
         request: UploadLogBinary,
     ) -> Result<EventId, C8YRestError> {
+        let mut sleep = 1;
         loop {
             let log_file_event = self
                 .create_event_request(
@@ -323,6 +332,9 @@ impl C8YHttpProxyActor {
                     | tedge_http_ext::HttpError::HttpStatusError(StatusCode::REQUEST_TIMEOUT) => {
                         // reset jwt token, so that we can get a fresh one on next iteration.
                         self.token = "".to_string();
+                        tokio::time::sleep(tokio::time::Duration::from_secs(sleep)).await;
+                        // Increase the sleep in exponential
+                        sleep *= 2;
                         continue;
                     }
                     e => return Err(C8YRestError::CustomError(e.to_string().into())),
@@ -335,6 +347,7 @@ impl C8YHttpProxyActor {
         &mut self,
         request: UploadConfigFile,
     ) -> Result<EventId, C8YRestError> {
+        let mut sleep = 1;
         loop {
             // read the config file contents
             let config_content = std::fs::read_to_string(request.config_path.clone())
@@ -378,6 +391,9 @@ impl C8YHttpProxyActor {
                     | tedge_http_ext::HttpError::HttpStatusError(StatusCode::REQUEST_TIMEOUT) => {
                         // reset jwt token, so that we can get a fresh one on next iteration.
                         self.token = "".to_string();
+                        tokio::time::sleep(tokio::time::Duration::from_secs(sleep)).await;
+                        // Increase the sleep in exponential
+                        sleep *= 2;
                         continue;
                     }
                     e => return Err(C8YRestError::CustomError(e.to_string().into())),
@@ -448,6 +464,7 @@ impl C8YHttpProxyActor {
         &mut self,
         c8y_event: C8yCreateEvent,
     ) -> Result<EventId, C8YRestError> {
+        let mut sleep = 1;
         loop {
             let create_event_url = self.end_point.get_url_for_create_event();
 
@@ -472,6 +489,9 @@ impl C8YHttpProxyActor {
                     | tedge_http_ext::HttpError::HttpStatusError(StatusCode::REQUEST_TIMEOUT) => {
                         // reset jwt token, so that we can get a fresh one on next iteration.
                         self.token = "".to_string();
+                        tokio::time::sleep(tokio::time::Duration::from_secs(sleep)).await;
+                        // Increase the sleep in exponential
+                        sleep *= 2;
                         continue;
                     }
                     e => return Err(C8YRestError::CustomError(e.to_string().into())),

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -391,6 +391,7 @@ impl C8YHttpProxyActor {
                     | tedge_http_ext::HttpError::HttpStatusError(StatusCode::REQUEST_TIMEOUT) => {
                         // reset jwt token, so that we can get a fresh one on next iteration.
                         self.token = "".to_string();
+                        self.end_point.c8y_internal_id = "".to_string();
                         tokio::time::sleep(tokio::time::Duration::from_secs(sleep)).await;
                         // Increase the sleep in exponential
                         sleep *= 2;

--- a/crates/extensions/c8y_http_proxy/src/actor.rs
+++ b/crates/extensions/c8y_http_proxy/src/actor.rs
@@ -390,13 +390,11 @@ impl C8YHttpProxyActor {
         if self.token.is_empty() {
             if let Ok(token) = self.peers.jwt.await_response(()).await? {
                 self.token = token.clone();
-                dbg!("fresh token.............");
                 Ok(token)
             } else {
                 Err(C8YRestError::CustomError("JWT token not available".into()))
             }
         } else {
-            dbg!("cached token..............");
             Ok(self.token.clone())
         }
     }

--- a/crates/extensions/c8y_mapper_ext/src/actor.rs
+++ b/crates/extensions/c8y_mapper_ext/src/actor.rs
@@ -107,8 +107,6 @@ async fn send_init_messages(actor: &mut C8yMapperActor) -> Result<(), RuntimeErr
             _ => {}
         }
     }
-
-    dbg!("done with initialization");
     Ok(())
 }
 
@@ -125,8 +123,6 @@ async fn check_status_and_send_init_messages(
                 .topic
                 .eq(&Topic::new_unchecked("tedge/commands/req/software/list"))
             {
-                dbg!(&init_message.topic.name);
-                dbg!(&init_message.payload_str().unwrap());
                 let _ = actor.mqtt_publisher.send(init_message.clone()).await?;
                 *received_agent_status = true;
             }
@@ -135,9 +131,6 @@ async fn check_status_and_send_init_messages(
         let init_messages = actor.converter.init_messages();
         for init_message in init_messages.into_iter() {
             if init_message.topic.name.contains("c8y/") {
-                dbg!(&init_message.topic.name);
-                dbg!(&init_message.payload_str().unwrap());
-
                 let _ = actor.mqtt_publisher.send(init_message.clone()).await?;
             }
         }

--- a/crates/extensions/c8y_mapper_ext/src/config.rs
+++ b/crates/extensions/c8y_mapper_ext/src/config.rs
@@ -93,6 +93,14 @@ impl C8yMapperConfig {
 
         Ok(topic_filter)
     }
+
+    pub fn init_subscriptions() -> Result<TopicFilter, C8yMapperConfigError> {
+        let topic_filter: TopicFilter = vec!["tedge/health/+"]
+            .try_into()
+            .expect("topics that mapper should subscribe to");
+
+        Ok(topic_filter)
+    }
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/extensions/c8y_mapper_ext/src/converter.rs
+++ b/crates/extensions/c8y_mapper_ext/src/converter.rs
@@ -1282,6 +1282,7 @@ mod tests {
             &Topic::new_unchecked("tedge/measurements/child2"),
             in_payload,
         );
+
         let out_second_messages = converter.convert(&in_second_message).await;
         let expected_second_smart_rest_message = Message::new(
             &Topic::new_unchecked("c8y/s/us"),

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -39,27 +39,6 @@ async fn mapper_publishes_init_messages_on_startup() {
 
     let mut mqtt = mqtt.with_timeout(TEST_TIMEOUT_MS);
 
-    mqtt.send(
-        MqttMessage::new(
-            &Topic::new_unchecked("tedge/health/mosquitto-c8y-bridge"),
-            "1",
-        )
-        .with_retain(),
-    )
-    .await
-    .expect("Send failed");
-
-    // Simulate c8y_SoftwareUpdate SmartREST request
-    mqtt.send(
-        MqttMessage::new(
-            &Topic::new_unchecked("tedge/health/tedge-agent"),
-            "{\"status\":\"up\"}",
-        )
-        .with_retain(),
-    )
-    .await
-    .expect("Send failed");
-
     let version = env!("CARGO_PKG_VERSION");
     let default_fragment_content = json!({
         "c8y_Agent": {
@@ -1296,6 +1275,7 @@ async fn spawn_c8y_mapper_actor(
     let c8y_mapper_builder = C8yMapperBuilder::try_new(
         config,
         &mut mqtt_builder,
+        // &mut health_mqtt_builder,
         &mut c8y_proxy_builder,
         &mut timer_builder,
         &mut fs_watcher_builder,
@@ -1303,6 +1283,7 @@ async fn spawn_c8y_mapper_actor(
     .unwrap();
 
     let mut actor = c8y_mapper_builder.build();
+
     tokio::spawn(async move { actor.run().await });
 
     let mut mqtt = mqtt_builder.build();

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -1275,7 +1275,6 @@ async fn spawn_c8y_mapper_actor(
     let c8y_mapper_builder = C8yMapperBuilder::try_new(
         config,
         &mut mqtt_builder,
-        // &mut health_mqtt_builder,
         &mut c8y_proxy_builder,
         &mut timer_builder,
         &mut fs_watcher_builder,

--- a/crates/extensions/c8y_mapper_ext/src/tests.rs
+++ b/crates/extensions/c8y_mapper_ext/src/tests.rs
@@ -29,7 +29,7 @@ use tedge_test_utils::fs::with_exec_permission;
 use tedge_test_utils::fs::TempTedgeDir;
 use tedge_timer_ext::Timeout;
 
-const TEST_TIMEOUT_MS: Duration = Duration::from_millis(10000);
+const TEST_TIMEOUT_MS: Duration = Duration::from_millis(5000);
 
 #[tokio::test]
 async fn mapper_publishes_init_messages_on_startup() {
@@ -70,7 +70,6 @@ async fn mapper_publishes_init_messages_on_startup() {
     })
     .to_string();
 
-    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
     assert_received_contains_str(
         &mut mqtt,
         [


### PR DESCRIPTION
## Proposed changes

- [x] Check the c8y bridge before sending init messages
- [x] Check the tedge-agent health status before sending the software list request
- [x] Cache the jwt token
- [x] Retry `get internal id` on failures
- [ ] Retry for all the HTTP interactions
- [ ] Retry on exponential waits

## Types of changes

<!--
What types of changes does your code introduce to `thin-edge.io`?
_Put an `x` in the boxes that apply_
-->

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (general improvements like code refactoring that doesn't explicitly fix a bug or add any new functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Paste Link to the issue
<br/>

## Checklist

<!--
_Put an `x` in the boxes that apply. You can also fill these out after
creating the PR. If you're unsure about any of them, don't hesitate to ask.
We're here to help! This is simply a reminder of what we are going to look for
before merging your code._
-->

- [ ] I have read the [CONTRIBUTING](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTING.md) doc
- [ ] I have signed the [CLA](https://github.com/thin-edge/thin-edge.io/blob/main/CONTRIBUTOR-LICENSE-AGREEMENT.md) (in all commits with git commit -s)
- [ ] I ran `cargo fmt` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I used `cargo clippy` as mentioned in [CODING_GUIDELINES](https://github.com/thin-edge/thin-edge.io/blob/main/CODING_GUIDELINES.md)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

<!--
If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you
considered, etc...
-->

